### PR TITLE
Save sti files with Pillow

### DIFF
--- a/examples/to_sti_16bit.py
+++ b/examples/to_sti_16bit.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+##############################################################################
+#
+# This file is part of JA2 Open Toolset
+#
+# JA2 Open Toolset is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# JA2 Open Toolset is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with JA2 Open Toolset.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import argparse
+import os
+import sys
+
+# search for ja2py in the parent dir of this file
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+# load the image plugin
+import ja2py.fileformats.Sti
+from PIL import Image
+
+
+def main():
+    parser = argparse.ArgumentParser(description='STI image creator - RGB')
+    parser.add_argument('FILE', help="path to the image file")
+    parser.add_argument(
+        '-o',
+        '--output',
+        default=None,
+        help="path to the output file. By default, it's FILE with the extension replaced with '.STI'"
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        action='store_true',
+        default=False,
+        help="be verbose, e.g. print the names of the files"
+    )
+    args = parser.parse_args()
+    output = args.output or os.path.splitext(args.FILE)[0] + ".STI"
+    if args.verbose:
+        print("Input file : {}".format(args.FILE))
+        print("Output file: {}".format(output))
+
+    img = Image.open(args.FILE)
+    img.save(output, format='STCI', flags=['RGB']) # calls StiImagePlugin._save_handler
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/to_sti_8bit.py
+++ b/examples/to_sti_8bit.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+##############################################################################
+#
+# This file is part of JA2 Open Toolset
+#
+# JA2 Open Toolset is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# JA2 Open Toolset is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with JA2 Open Toolset.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import argparse
+import os
+import sys
+
+# search for ja2py in the parent dir of this file
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+# load the image plugin
+import ja2py.fileformats.Sti
+from PIL import Image
+
+
+def main():
+    parser = argparse.ArgumentParser(description='STI image creator - INDEXED ETRLE')
+    parser.add_argument('files', metavar='FILE', nargs='+', help="path to an image file")
+    parser.add_argument(
+        '-o',
+        '--output',
+        default=None,
+        help="path to the output file. By default, it's the first FILE with the extension replaced with '.STI'"
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        action='store_true',
+        default=False,
+        help="be verbose, e.g. print the names of the files"
+    )
+    args = parser.parse_args()
+    output = args.output or os.path.splitext(args.files[0])[0] + ".STI"
+    if args.verbose:
+        for file in args.files:
+            print("Input file : {}".format(file))
+        print("Output file: {}".format(output))
+
+    images = [Image.open(file) for file in args.files]
+    images[0].save(output, format='STCI', save_all=True, flags=['INDEXED', 'ETRLE'], append_images=images[1:]) # calls StiImagePlugin._save_all_handler
+
+
+if __name__ == "__main__":
+    main()

--- a/ja2py/fileformats/Sti.py
+++ b/ja2py/fileformats/Sti.py
@@ -1178,6 +1178,8 @@ class StiImageEncoder(PyEncoder):
                     self.bytes.extend(line[:n])
                 line = line[n:]
             self.bytes.append(0) # end of line, control with length 0
+        else:
+            self.y = y1
         if len(self.bytes) > bufsize:
             buffer = bytes(self.bytes[:bufsize])
             self.bytes = self.bytes[bufsize:]

--- a/ja2py/fileformats/Sti.py
+++ b/ja2py/fileformats/Sti.py
@@ -1018,7 +1018,7 @@ class StiImageEncoder(PyEncoder):
     Encoder for images in a STI file.
 
     ```
-    img.tobytes(StiImagePlugin.format, 'colors', spec) # defaults to official spec
+    img.tobytes(StiImagePlugin.format, 'colors', (spec,)) # defaults to official spec
     img.tobytes(StiImagePlugin.format, 'indexes')
     img.tobytes(StiImagePlugin.format, 'etrle')
     ```

--- a/ja2py/fileformats/Sti.py
+++ b/ja2py/fileformats/Sti.py
@@ -650,7 +650,8 @@ class StiImagePlugin(ImageFile.ImageFile):
                         a = 0
                     elif semi_transparent == 'opaque':
                         a = 255
-                    raise ValueError("semi transparent color found, to auto-convert you can set 'semi_transparent' to 'transparent' or 'opaque'")
+                    else:
+                        raise ValueError("semi transparent color found, to auto-convert you can set 'semi_transparent' to 'transparent' or 'opaque' {}".format(color))
                 if a == 0:
                     data.append(0) # transparent
                 else:

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -635,6 +635,25 @@ class TestStiImageEncoder(unittest.TestCase):
         img.putdata(data)
         self.assertEqual(img.tobytes(StiImagePlugin.format, 'indexes'), bytes)
 
+    def test_indexes_small_bufsize(self):
+        data = [1, 2,
+                3, 4]
+        want = [b'\x01', b'\x02',
+                b'\x03', b'\x04']
+        img = Image.new('P', (2, 2))
+        img.putdata(data)
+        have = []
+        encoder = Image._getencoder('P', StiImagePlugin.format, 'indexes')
+        encoder.setimage(img.im)
+        for i in range(4):
+            n, errcode, buffer = encoder.encode(1)
+            have.append(buffer)
+            if errcode > 0:
+                break
+        else:
+            assert False, "too many encode cycles"
+        self.assertEqual(have, want)
+
     def test_etrle(self):
         data = [1, 2,
                 3, 4]

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -635,7 +635,7 @@ class TestStiImageEncoder(unittest.TestCase):
         img = Image.new('RGBA', (2, 2))
         img.putdata(data)
         have = []
-        encoder = Image._getencoder('RGBA', StiImagePlugin.format, 'colors', spec,)
+        encoder = Image._getencoder('RGBA', StiImagePlugin.format, 'colors', (spec,))
         encoder.setimage(img.im)
         for i in range(len(want)):
             n, errcode, buffer = encoder.encode(1)

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -687,3 +687,22 @@ class TestStiImageEncoder(unittest.TestCase):
         img.putdata(data)
         self.assertEqual(img.tobytes(StiImagePlugin.format, 'etrle'), bytes)
 
+    def test_etrle_small_bufsize(self):
+        data = [1, 2,
+                3, 4]
+        want = [b'\x02\x01', b'\x02\x00',
+                b'\x02\x03', b'\x04\x00']
+        img = Image.new('P', (2, 2))
+        img.putdata(data)
+        have = []
+        encoder = Image._getencoder('P', StiImagePlugin.format, 'etrle')
+        encoder.setimage(img.im)
+        for i in range(4):
+            n, errcode, buffer = encoder.encode(2)
+            have.append(buffer)
+            if errcode > 0:
+                break
+        else:
+            assert False, "too many encode cycles"
+        self.assertEqual(have, want)
+

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -608,6 +608,24 @@ class TestStiImageEncoder(unittest.TestCase):
         img.putdata(data)
         self.assertEqual(img.tobytes(StiImagePlugin.format, 'colors', 'RGB'), bytes)
 
+    def test_colors_force_alpha(self):
+        data = [(0,1,2), (3,4,5),
+                (6,7,8), (9,10,11)]
+        bytes = b'\x00\x01\x02\xff\x03\x04\x05\xff'\
+              + b'\x06\x07\x08\xff\x09\x0a\x0b\xff'
+        img = Image.new('RGB', (2, 2))
+        img.putdata(data)
+        self.assertEqual(img.tobytes(StiImagePlugin.format, 'colors', 'RGBA'), bytes)
+
+    def test_colors_force_no_alpha(self):
+        data = [(0,1,2,255), (3,4,5,200),
+                (6,7,8,100), (9,10,11,0)]
+        bytes = b'\x00\x01\x02\x03\x04\x05'\
+              + b'\x06\x07\x08\x09\x0a\x0b'
+        img = Image.new('RGBA', (2, 2))
+        img.putdata(data)
+        self.assertEqual(img.tobytes(StiImagePlugin.format, 'colors', 'RGB'), bytes)
+
     def test_indexes(self):
         data = [1, 2,
                 3, 4]

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -4,7 +4,7 @@ from .fixtures import *
 from ja2py.fileformats import Sti16BitHeader, Sti8BitHeader, StiHeader, StiSubImageHeader, AuxObjectData,\
                               is_16bit_sti, is_8bit_sti, load_16bit_sti, load_8bit_sti, save_16bit_sti, save_8bit_sti
 from ja2py.content import Image16Bit, Images8Bit, SubImage8Bit
-from ja2py.fileformats.Sti import StiImagePlugin
+from ja2py.fileformats.Sti import StiImagePlugin, StiImageEncoder
 
 
 class TestSti16BitHeader(unittest.TestCase):
@@ -606,6 +606,7 @@ class TestStiImageEncoder(unittest.TestCase):
               + b'\x06\x07\x08\x09\x0a\x0b'
         img = Image.new('RGB', (2, 2))
         img.putdata(data)
+        self.assertIn('RGB', StiImageEncoder.RAWMODES)
         self.assertEqual(img.tobytes(StiImagePlugin.format, 'colors', 'RGB'), bytes)
 
     def test_colors_force_alpha(self):
@@ -635,7 +636,7 @@ class TestStiImageEncoder(unittest.TestCase):
         img = Image.new('RGBA', (2, 2))
         img.putdata(data)
         have = []
-        encoder = Image._getencoder('RGBA', StiImagePlugin.format, 'colors', (spec,))
+        encoder = StiImageEncoder('RGBA', 'colors', spec)
         encoder.setimage(img.im)
         for i in range(len(want)):
             n, errcode, buffer = encoder.encode(1)
@@ -663,7 +664,7 @@ class TestStiImageEncoder(unittest.TestCase):
         img = Image.new('P', (2, 2))
         img.putdata(data)
         have = []
-        encoder = Image._getencoder('P', StiImagePlugin.format, 'indexes')
+        encoder = StiImageEncoder('P', 'indexes')
         encoder.setimage(img.im)
         for i in range(len(want)):
             n, errcode, buffer = encoder.encode(1)
@@ -734,7 +735,7 @@ class TestStiImageEncoder(unittest.TestCase):
         img = Image.new('P', (2, 2))
         img.putdata(data)
         have = []
-        encoder = Image._getencoder('P', StiImagePlugin.format, 'etrle')
+        encoder = StiImageEncoder('P', 'etrle')
         encoder.setimage(img.im)
         for i in range(len(want)):
             n, errcode, buffer = encoder.encode(2)
@@ -751,7 +752,7 @@ class TestStiImageEncoder(unittest.TestCase):
         img.putdata(data)
         with self.assertRaises(NotImplementedError):
             img.tobytes(StiImagePlugin.format, 'not_implemented')
-        encoder = Image._getencoder('P', StiImagePlugin.format, 'indexes')
+        encoder = StiImageEncoder('P', 'indexes')
         encoder.setimage(img.im)
         encoder.do = 'not_implemented' # override 'indexes'
         with self.assertRaises(NotImplementedError):

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -626,6 +626,26 @@ class TestStiImageEncoder(unittest.TestCase):
         img.putdata(data)
         self.assertEqual(img.tobytes(StiImagePlugin.format, 'colors', 'RGB'), bytes)
 
+    def test_colors_small_bufsize(self):
+        data = [(0x00,0x00,0x00,0x00), (0xff,0xff,0xff,0xff),
+                (0x0f,0x0f,0x0f,0x0f), (0xf0,0xf0,0xf0,0xf0)]
+        want = [b'\x00', b'\x00', b'\xff', b'\xff',
+                b'\x00', b'\x00', b'\xff', b'\xff']
+        spec = (0x000f,0xf000,0x00f0,0x0f00, 4,4,4,4, 16)
+        img = Image.new('RGBA', (2, 2))
+        img.putdata(data)
+        have = []
+        encoder = Image._getencoder('RGBA', StiImagePlugin.format, 'colors', spec,)
+        encoder.setimage(img.im)
+        for i in range(len(want)):
+            n, errcode, buffer = encoder.encode(1)
+            have.append(buffer)
+            if errcode > 0:
+                break
+        else:
+            assert False, "too many encode cycles"
+        self.assertEqual(have, want)
+
     def test_indexes(self):
         data = [1, 2,
                 3, 4]
@@ -645,7 +665,7 @@ class TestStiImageEncoder(unittest.TestCase):
         have = []
         encoder = Image._getencoder('P', StiImagePlugin.format, 'indexes')
         encoder.setimage(img.im)
-        for i in range(4):
+        for i in range(len(want)):
             n, errcode, buffer = encoder.encode(1)
             have.append(buffer)
             if errcode > 0:
@@ -716,7 +736,7 @@ class TestStiImageEncoder(unittest.TestCase):
         have = []
         encoder = Image._getencoder('P', StiImagePlugin.format, 'etrle')
         encoder.setimage(img.im)
-        for i in range(4):
+        for i in range(len(want)):
             n, errcode, buffer = encoder.encode(2)
             have.append(buffer)
             if errcode > 0:

--- a/test/ja2py/fileformats/test_Sti.py
+++ b/test/ja2py/fileformats/test_Sti.py
@@ -745,3 +745,15 @@ class TestStiImageEncoder(unittest.TestCase):
             assert False, "too many encode cycles"
         self.assertEqual(have, want)
 
+    def test_not_implemented(self):
+        data = [0]
+        img = Image.new('P', (1, 1))
+        img.putdata(data)
+        with self.assertRaises(NotImplementedError):
+            img.tobytes(StiImagePlugin.format, 'not_implemented')
+        encoder = Image._getencoder('P', StiImagePlugin.format, 'indexes')
+        encoder.setimage(img.im)
+        encoder.do = 'not_implemented' # override 'indexes'
+        with self.assertRaises(NotImplementedError):
+            encoder.encode()
+


### PR DESCRIPTION
Was playing around with Pillow and implemented the other things that can be registered.

You can now save RGB and INDEXED sti files with Pillow.
It gives you control of how to save with the parameters to `Image.save`.
You can choose the RGBA spec it uses (defaults to the official spec).
The palette in INDEXED ETRLE images is created from the contents of the images.
ETRLE compression is optional.
You can choose the transparent color (palette index 0).
You can choose how semi-transparent pixels are handled.
Missing image offsets and aux_object_data have default values.

The only thing left is reading the INDEXED images as frames, but I'm not in the mood to play with Pillow anymore so this is it.

PS- what is your versioning policy? I think new capabilities should bump the version