### PR TITLE
gmtime with negative timestamp causes OSError on Windows

### DIFF
--- a/ja2py/fileformats/SlfFS.py
+++ b/ja2py/fileformats/SlfFS.py
@@ -51,9 +51,12 @@ class SlfEntry(Ja2FileHeader):
     def map_raw_to_attrs(raw):
         attrs = raw.copy()
         attrs['file_name'] = decode_ja2_string(raw['file_name'])
-        ts = float(raw['time']) / 10000000.0 - 11644473600.0
-        if os.name != 'nt' or ts > 0:  ## negative ts causes error on Windows: https://bugs.python.org/issue36439
-            attrs['time'] = gmtime(ts)
+        try:
+            attrs['time'] = gmtime(float(raw['time']) / 10000000.0 - 11644473600.0)
+        except OSError:
+            ## negative ts causes error on Windows: https://bugs.python.org/issue36439
+            attrs['time'] = gmtime(0)
+
         return attrs
 
     @staticmethod

--- a/ja2py/fileformats/SlfFS.py
+++ b/ja2py/fileformats/SlfFS.py
@@ -51,7 +51,9 @@ class SlfEntry(Ja2FileHeader):
     def map_raw_to_attrs(raw):
         attrs = raw.copy()
         attrs['file_name'] = decode_ja2_string(raw['file_name'])
-        attrs['time'] = gmtime(float(raw['time']) / 10000000.0 - 11644473600.0)
+        ts = float(raw['time']) / 10000000.0 - 11644473600.0
+        if os.name != 'nt' or ts > 0:  ## negative ts causes error on Windows: https://bugs.python.org/issue36439
+            attrs['time'] = gmtime(ts)
         return attrs
 
     @staticmethod


### PR DESCRIPTION
`SlfFS` runs into error on Windows. It causes an error like this:

```
Traceback (most recent call last):
  File "install_wildfire_maps.py", line 153, in <module>
    main()
  File "install_wildfire_maps.py", line 46, in main
    unpack_slf(work_dir, slf)
  File "install_wildfire_maps.py", line 84, in unpack_slf
    combined_fs = open_slf_for_copy(work_path, slf_name)
  File "install_wildfire_maps.py", line 104, in open_slf_for_copy
    slf_fs = SlfFS(str(slf_file))
  File "D:\Workspace\mod-wildfire-maps\lib\ja2-open-toolset\ja2py\fileformats\SlfFS.py", line 141, in __init__
    self.entries = list(map(self._read_entry, range(self.header['number_of_entries'])))
  File "D:\Workspace\mod-wildfire-maps\lib\ja2-open-toolset\ja2py\fileformats\SlfFS.py", line 167, in _read_entry
    return SlfEntry.from_bytes(self.file.read(entry_size))
  File "D:\Workspace\mod-wildfire-maps\lib\ja2-open-toolset\ja2py\fileformats\common.py", line 93, in from_bytes
    kwargs = cls.map_raw_to_attrs(dict(zip(cls.keys(), struct.unpack(cls._get_struct_format(), byte_str))))
  File "D:\Workspace\mod-wildfire-maps\lib\ja2-open-toolset\ja2py\fileformats\SlfFS.py", line 57, in map_raw_to_attrs
    attrs['time'] = gmtime(ts)
OSError: [Errno 22] Invalid argument
```

It is a Windows-only issue. In this case  `raw['time']` is zero, the timestamp seems invalid anyways. It still happens on Python 3.8.2.

See https://bugs.python.org/issue36439