### PR TITLE
Fixing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
-  - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - "pip install -e ."
   - "pip install -r requirements-dev.txt"


### PR DESCRIPTION
Older Python 3 versions are no longer available on Travis. Updating to newer versions. 

See https://docs.travis-ci.com/user/languages/python/#python-versions, for the default Ubuntu 16.04, the available Python versions are >= 3.4+.