### PR TITLE
Dump data from NPCDATA

### DIFF
--- a/examples/dump_npc_records.py
+++ b/examples/dump_npc_records.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+##############################################################################
+#
+# This file is part of JA2 Open Toolset
+#
+# JA2 Open Toolset is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# JA2 Open Toolset is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with JA2 Open Toolset.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+import os
+import sys
+import argparse
+
+# search for ja2py in the parent dir of this file
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+from ja2py.content.Npc import NpcData, NPC_RECORD_LENGTH
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Dump NPCDATA file')
+    parser.add_argument('npc_file', help="path to the NPC file")
+    args = parser.parse_args()
+
+    with open(args.npc_file, 'rb') as npc_file:
+        idx = 0
+        while True:
+            b = npc_file.read(NPC_RECORD_LENGTH)
+            if len(b) < NPC_RECORD_LENGTH:
+                break
+            record = NpcData(b)
+            print("Record #{}".format(idx))
+            idx = idx + 1
+            record.pretty_print()
+
+
+if __name__ == "__main__":
+    main()

--- a/ja2py/content/Npc.py
+++ b/ja2py/content/Npc.py
@@ -1,0 +1,84 @@
+NPC_RECORD_LENGTH = 32
+
+
+class NpcData(object):
+    def __init__(self, bytes):
+        ## TODO: support RUSSIAN version
+        data = {}
+        data['ubIdentifier'] = 0
+        data['fFlags'] = _format_flags(bytes[0:2])
+        data['usFactMustBeTrue'] = _format_fact(read_uint(bytes[4:6]))
+        data['usFactMustBeFalse'] = _format_fact(read_uint(bytes[6:8]))
+        data['ubQuest'] = _format_quest(read_uint([bytes[8]]))
+        data['ubFirstDay'] = read_uint([bytes[9]])
+        data['ubLastDay'] = read_uint([bytes[10]])
+        data['ubApproachRequired'] = read_uint([bytes[11]])
+        data['ubOpinionRequired'] = read_uint([bytes[12]])
+        data['ubQuoteNum'] = read_uint([bytes[13]])
+        data['ubNumQuotes'] = read_uint([bytes[14]])
+        data['ubStartQuest'] = _format_quest(read_uint([bytes[15]]))
+        data['ubEndQuest'] = _format_quest(read_uint([bytes[16]]))
+        data['ubTriggerNPC'] = read_uint([bytes[17]])
+        data['ubTriggerNPCRec'] = read_uint([bytes[18]])
+        data['usSetFactTrue'] = _format_fact(read_uint(bytes[20:22]))
+        data['usGiftItem'] = read_uint(bytes[22:23])
+        data['usGoToGridno'] = read_uint(bytes[24:26])
+        data['sActionData'] = read_int(bytes[26:28])
+
+        r = read_int(bytes[2:4])
+        data['sRequiredItem'] = str(r) if r > 0 else 'NOTHING'
+        data['sRequiredGridno'] = str(-r) if r < 0 else 'N/A'
+        self._data = data
+
+    @property
+    def data(self):
+        return self._data
+
+    def pretty_print(self):
+        print("""========================================
+  fFlags:                {fFlags}
+  sRequiredItem:         {sRequiredItem}
+  sRequiredGridno:       {sRequiredGridno}
+  usFactMustBeTrue:      {usFactMustBeTrue}
+  usFactMustBeFalse:     {usFactMustBeFalse}
+  ubQuest:               {ubQuest}
+  ubFirstDay :           {ubFirstDay}
+  ubLastDay:             {ubLastDay}
+  ubApproachRequired:    {ubApproachRequired}
+  ubOpinionRequired:     {ubOpinionRequired}
+  ubQuoteNum:            {ubQuoteNum}
+  ubNumQuotes:           {ubNumQuotes}
+  ubStartQuest:          {ubStartQuest}
+  ubEndQuest:            {ubEndQuest}
+  ubTriggerNPC:          {ubTriggerNPC}
+  ubTriggerNPCRec:       {ubTriggerNPCRec}
+  usSetFactTrue:         {usSetFactTrue}
+  usGiftItem:            {usGiftItem}
+  usGoToGridno:          {usGoToGridno}
+  sActionData:           {sActionData}
+""".format(**self._data))
+
+
+def read_uint(bytes):
+    return int.from_bytes(bytes, byteorder='little', signed=False)
+
+
+def read_int(bytes):
+    return int.from_bytes(bytes, byteorder='little', signed=True)
+
+
+def _format_fact(fact_num):
+    if fact_num == 65535:
+        return 'NO_FACT'
+    return str(fact_num)
+
+
+def _format_quest(quest):
+    if quest == 255:
+        return 'NO_QUEST'
+    return str(quest)
+
+
+def _format_flags(bytes):
+    flags_len = len(bytes) * 8
+    return '{:b}'.format(read_uint(bytes)).rjust(flags_len, '0')


### PR DESCRIPTION
I wanted to examine some NPC data. Not having access to a Windows environment and preferring a command line tool, I wrote this Python module referencing [TacticalAI/NPC.cc](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/master/src/game/TacticalAI/NPC.cc#L161).

This module extracts data from `NPCDATA/*.NPC`, exposes the data as `dict` and comes with a `pretty_print` function. This does not support Russian version game data.

Example output:

```
# python3 examples/dump_npc_records.py ./tmp/061.NPC
Record #0
========================================
  fFlags:                00000000000000000
  sRequiredItem:         NOTHING
  sRequiredGridno:       N/A
  usFactMustBeTrue:      NO_FACT
  usFactMustBeFalse:     NO_FACT
  ubQuest:               NO_QUEST
  ubFirstDay :           0
  ubLastDay:             255
  ubApproachRequired:    10
  ubOpinionRequired:     0
  ubQuoteNum:            24
  ubNumQuotes:           1
  ubStartQuest:          NO_QUEST
  ubEndQuest:            NO_QUEST
  ubTriggerNPC:          255
  ubTriggerNPCRec:       255
  usSetFactTrue:         427
  usGiftItem:            0
  usGoToGridno:          65535
  sActionData:           22

Record #1
========================================
...
```